### PR TITLE
replace spatstat.core by spatstat.explore

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,10 +18,20 @@ Authors@R: c(
 Depends:
     R (>= 3.4.0)
 Imports:
-    raster, igraph, VGAM, sp, graphics, stats, viridis, rgeos, spatstat.core, spatstat.geom, poweRlaw
+    raster,
+    igraph,
+    VGAM,
+    sp,
+    graphics,
+    stats,
+    viridis,
+    rgeos,
+    spatstat.explore,
+    spatstat.geom,
+    poweRlaw
 Description: Set of tools for detecting and analyzing Airborne Laser Scanning-derived Tropical Forest Canopy Gaps. Details were published in Silva et al. (2019) <doi:10.1111/2041-210X.13211>.
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/R/GapsSpatPattern.R
+++ b/R/GapsSpatPattern.R
@@ -12,9 +12,11 @@
 #' @return A plot with Ripley's K- and L-functions. Value of Clark-Evans index (R) and test for randomness (R=1), aggregation (R<1) or uniform distribution (R>1).
 #' @author Ruben Valbuena and Carlos Alberto Silva.
 #' @references
-#' [`spatstat`][spatstat.core::spatstat.core-package] package, see [`Lest()`][spatstat.core::Lest()], [`Kest()`][spatstat.core::Kest()],
-#' and [`clarkevans.test()`][spatstat.core::clarkevans.test()].
-#'
+#' \code{\link[spatstat.explore]{spatstat.explore-package}}, see 
+#' \code{\link[spatstat.explore]{Lest}},
+#' \code{\link[spatstat.explore]{Kest}} and 
+#' \code{\link[spatstat.explore]{clarkevans.test}}
+#' 
 #' @examples
 #' # This takes > 5 seconds!
 #' \donttest{
@@ -47,11 +49,11 @@ GapsSpatPattern <- function(gap_SPDF_layer, chm_layer) {
   oldpar <- graphics::par(no.readonly = TRUE)
   on.exit(graphics::par(oldpar)) 
   P <- spatstat.geom::as.ppp(sp::coordinates(gap_SPDF_layer), raster::extent(chm_layer)[])
-  K <- spatstat.core::envelope(P, spatstat.core::Kest, nsim = 99, verbose = F)
-  L <- spatstat.core::envelope(P, spatstat.core::Lest, nsim = 99, verbose = F)
+  K <- spatstat.explore::envelope(P, spatstat.explore::Kest, nsim = 99, verbose = F)
+  L <- spatstat.explore::envelope(P, spatstat.explore::Lest, nsim = 99, verbose = F)
   graphics::par(mfrow = c(1, 2), mar = c(6, 5, 4, 2))
   graphics::plot(K)
   graphics::plot(L)
-  CE <- spatstat.core::clarkevans.test(P)
+  CE <- spatstat.explore::clarkevans.test(P)
   return(CE)
 }

--- a/man/GapsSpatPattern.Rd
+++ b/man/GapsSpatPattern.Rd
@@ -49,8 +49,10 @@ gaps_cau2014_SpatPattern <- GapsSpatPattern(gaps_cau2014_spdf, ALS_CHM_CAU_2014)
 }
 }
 \references{
-\code{\link[spatstat.core:spatstat.core-package]{spatstat}} package, see \code{\link[spatstat.core:Lest]{Lest()}}, \code{\link[spatstat.core:Kest]{Kest()}},
-and \code{\link[spatstat.core:clarkevans.test]{clarkevans.test()}}.
+\code{\link[spatstat.explore]{spatstat.explore-package}}, see
+\code{\link[spatstat.explore]{Lest}},
+\code{\link[spatstat.explore]{Kest}} and
+\code{\link[spatstat.explore]{clarkevans.test}}
 }
 \author{
 Ruben Valbuena and Carlos Alberto Silva.


### PR DESCRIPTION
I learned about the `ForestGapR` package and wanted to try it out. But I couldn’t install it.
Neither from CRAN:

``` r
install.packages("ForestGapR")
#> Warning: package 'ForestGapR' is not available for this version of R
#> 
#> A version of this package for your version of R might be available elsewhere,
#> see the ideas at
#> https://cran.r-project.org/doc/manuals/r-patched/R-admin.html#Installing-packages
```

nor from GitHub:

``` r
devtools::install_github("carlos-alberto-silva/ForestGapR")
#> Downloading GitHub repo carlos-alberto-silva/ForestGapR@HEAD
#> Skipping 1 packages not available: spatstat.core
#> * checking for file ‘/private/var/folders/78/771bmn3d7v1g0g8h11vjrwdc0000gn/T/RtmpuwDZn2/remotes7af29abffe4/carlos-alberto-silva-ForestGapR-c781ed0/DESCRIPTION’ ... OK
#> * preparing ‘ForestGapR’:
#> * checking DESCRIPTION meta-information ... OK
#> * checking for LF line-endings in source and make files and shell scripts
#> * checking for empty or unneeded directories
#> * building ‘ForestGapR_0.1.6.tar.gz’
#> Warning in i.p(...): installation of package '/var/folders/
#> 78/771bmn3d7v1g0g8h11vjrwdc0000gn/T//RtmpuwDZn2/file7af5b2ce71b/
#> ForestGapR_0.1.6.tar.gz' had non-zero exit status
```

So the message generated when trying to install from GitHub tells us that the package `spatstat.core` is no longer available. The [changelog of the spatstat package family](https://github.com/spatstat/spatstat/blob/master/NEWS) (CHANGES IN spatstat VERSION 3.0-0 =\> SIGNIFICANT USER-VISIBLE CHANGES) notes that the package `spatstat.core` has been split into two: `spatstat.explore` and `spatstat.model`. So I [modified](https://github.com/a-benini/ForestGapR/commit/1ff0aedf319ab5d448d875ee0f67dc2be2653e24) `ForestGapR`.

I just replaced `spatstat.core` by `spatstat.explore`; for all the relevant functions previously built into `GapsSpatPattern()` seem to have been moved to the `spatstat.explore` package.

I’m able to install my version of `ForestGapR` (macOS Big Sur 11.7 / R 4.2.2 & Windows 10.1 / R 4.2.1).

``` r
devtools::install_github("a-benini/ForestGapR", ref = "replace-spatstat.core")
#> Downloading GitHub repo a-benini/ForestGapR@replace-spatstat.core
#> 
#> * checking for file ‘/private/var/folders/78/771bmn3d7v1g0g8h11vjrwdc0000gn/T/RtmpuwDZn2/remotes7af6282b59a/a-benini-ForestGapR-1ff0aed/DESCRIPTION’ ... OK
#> * preparing ‘ForestGapR’:
#> * checking DESCRIPTION meta-information ... OK
#> * checking for LF line-endings in source and make files and shell scripts
#> * checking for empty or unneeded directories
#> * building ‘ForestGapR_0.1.6.tar.gz’
```

And the examples on help pages seem to work properly.
As a quick fix this does it for getting an installable and working version of `ForestGapR`. But I do want to mention that I ran a check on macOS Big Sur 11.7 resulting in a note:

``` r
# ── R CMD check results ───────────────────────────────── ForestGapR 0.1.6 ────
# Duration: 53.4s
#
# ❯ checking dependencies in R code ... NOTE
# Namespaces in Imports field not imported from:
#   ‘igraph’ ‘rgeos’ ‘viridis’
# All declared Imports should be used.
#
# 0 errors ✔ | 0 warnings ✔ | 1 note ✖
#
# R CMD check succeeded
```

So there seem to be some (at the time maybe not very urgent) issues with other packages built into `ForestGapR`. I didn’t do any research on this, but suspect these issues to be partly related to the retirement resp. aging of the packages `sp`, `raster` and `rgeos` (s. [here](https://r-spatial.org/r/2022/04/12/evolution.html) and [here](https://r-spatial.org/r/2022/12/14/evolution2.html)). It would be great if you could look into this. Thanks!

<sup>Created on 2023-01-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>